### PR TITLE
fix: return GaxiosError directly

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -419,9 +419,7 @@ export class Upload extends Pumpify {
 
     const res = await this.authClient.request(reqOpts);
     if (res.data && res.data.error) {
-      const err = new Error(res.data.error) as GaxiosError;
-      err.response = res;
-      throw err;
+      throw res.data.error;
     }
     // If no error was returned, but the response had an invalid status
     // code, create a new error to be passed to the callback.

--- a/test/test.ts
+++ b/test/test.ts
@@ -744,27 +744,28 @@ describe('gcs-resumable-upload', () => {
     });
 
     it('should execute the callback with a body error & response', async () => {
-      const response = {error: ':('};
+      const error = new GaxiosError(
+          'Error message', {},
+          {config: {}, data: {}, status: 500, headers: {}});
       mockAuthorizeRequest();
-      const scope = nock(REQ_OPTS.url).get(queryPath).reply(500, response);
+      const scope = nock(REQ_OPTS.url).get(queryPath).reply(500, {error});
       await assertRejects(up.makeRequest(REQ_OPTS), (err: GaxiosError) => {
-        assert.equal(err.response!.status, 500);
-        assert.deepStrictEqual(response, err.response!.data);
+        scope.done();
+        assert.strictEqual(err.code, '500');
         return true;
       });
     });
 
     it('should execute the callback with a body error & response for non-2xx status codes',
        async () => {
-         const response = {status: 500, data: {error: '!$#@'}};
+         const error = new GaxiosError(
+             'Error message', {},
+             {config: {}, data: {}, status: 500, headers: {}});
          mockAuthorizeRequest();
-         const scope =
-             nock(REQ_OPTS.url).get(queryPath).reply(500, response.data);
+         const scope = nock(REQ_OPTS.url).get(queryPath).reply(500, {error});
          await assertRejects(up.makeRequest(REQ_OPTS), (err: GaxiosError) => {
            scope.done();
-           assert.strictEqual(err.message, response.data.error);
-           assert.deepStrictEqual(err.response!.status, 500);
-           assert.deepStrictEqual(err.response!.data, response.data);
+           assert.deepStrictEqual(err.code, '500');
            return true;
          });
        });


### PR DESCRIPTION
The previous code was taking a GaxiosError, which is an object, and passing it into the constructor of a generic Error class. Error classes are only meant to receive a string, so the error being returned to the user was `[object Object]`. This just returns the Gaxios error directly!