### PR TITLE
fix: pass query parameters correctly

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,8 +11,10 @@ import {createHash} from 'crypto';
 import {GaxiosOptions, GaxiosPromise, GaxiosResponse} from 'gaxios';
 import {GoogleAuth, GoogleAuthOptions} from 'google-auth-library';
 import * as Pumpify from 'pumpify';
+import * as querystring from 'querystring';
 import {PassThrough, Transform} from 'stream';
 import * as streamEvents from 'stream-events';
+import {URL} from 'url';
 
 const BASE_URI = 'https://www.googleapis.com/upload/storage/v1/b';
 const TERMINATED_UPLOAD_STATUS_CODE = 410;
@@ -338,12 +340,18 @@ export class Upload extends Pumpify {
       this.unpipe(requestStreamEmbeddedStream);
     });
 
+    const parsedUrl = new URL(this.uri!);
+    const url = `${parsedUrl.origin}${parsedUrl.pathname}`;
+    const params =
+        querystring.parse(parsedUrl.search.substr(1));  // removes `?`
+
     const reqOpts: GaxiosOptions = {
       method: 'PUT',
-      url: this.uri,
+      url,
       headers: {
         'Content-Range': 'bytes ' + this.offset + '-*/' + this.contentLength
       },
+      params,
       body: requestStreamEmbeddedStream,
     };
 

--- a/test/test.ts
+++ b/test/test.ts
@@ -373,23 +373,25 @@ describe('gcs-resumable-upload', () => {
   });
 
   describe('#startUploading', () => {
+    const URI = 'https://uri/path?param=true';
+
     beforeEach(() => {
+      up.uri = URI;
       up.makeRequestStream = async () => through();
     });
 
     it('should make the correct request', (done) => {
-      const URI = 'uri';
       const OFFSET = 8;
 
-      up.uri = URI;
       up.offset = OFFSET;
 
       up.makeRequestStream = async (reqOpts: GaxiosOptions) => {
         assert.strictEqual(reqOpts.method, 'PUT');
-        assert.strictEqual(reqOpts.url, up.uri);
+        assert.strictEqual(reqOpts.url, 'https://uri/path');
         assert.deepEqual(
             reqOpts.headers,
             {'Content-Range': 'bytes ' + OFFSET + '-*/' + up.contentLength});
+        assert.deepEqual(reqOpts.params, {param: 'true'});
         done();
         return through();
       };


### PR DESCRIPTION
Fixes https://github.com/googleapis/nodejs-storage/pull/619

When I swapped request out for gaxios, I didn't notice that when you provide a URL to gaxios, it doesn't split out the query string parameters automatically. This does it manually, so that the correct URL is "PUT" to when uploading data.

The weird part is that the system tests should have failed before and should pass now, but they pass both with and without this change. The issue was first noticed here: https://github.com/googleapis/nodejs-storage/pull/619, and this change fixes that issue.