### PR TITLE
feat: support ConfigStore configPath option

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,13 @@ See [`authConfig`](https://github.com/google/google-auth-library-nodejs/#choosin
 
 The name of the destination bucket.
 
+###### config.configPath
+
+- Type: `string`
+- *Optional*
+
+Where the gcs-resumable-upload configuration file should be stored on your system. This maps to the [configstore option by the same name](https://github.com/yeoman/configstore/tree/0df1ec950d952b1f0dfb39ce22af8e505dffc71a#configpath).
+
 ###### config.file
 
 - Type: `string`

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,6 +48,12 @@ export interface UploadConfig {
   authClient?: GoogleAuth;
 
   /**
+   * Where the gcs-resumable-upload configuration file should be stored on your
+   * system. This maps to the configstore option by the same name.
+   */
+  configPath?: string;
+
+  /**
    * This will cause the upload to fail if the current generation of the remote
    * object does not match the one provided here.
    */
@@ -194,7 +200,9 @@ export class Upload extends Pumpify {
     if (cfg.private) this.predefinedAcl = 'private';
     if (cfg.public) this.predefinedAcl = 'publicRead';
 
-    this.configStore = new ConfigStore('gcs-resumable-upload');
+    const configPath = cfg.configPath;
+    this.configStore = new ConfigStore('gcs-resumable-upload', {configPath});
+
     this.uriProvidedManually = !!cfg.uri;
     this.uri = cfg.uri || this.get('uri');
     this.numBytesWritten = 0;

--- a/test/test.ts
+++ b/test/test.ts
@@ -39,6 +39,10 @@ class AbortController {
 
 let configData = {} as {[index: string]: {}};
 class ConfigStore {
+  constructor(packageName: string, config: object) {
+    this.set('packageName', packageName);
+    this.set('config', config);
+  }
   delete(key: string) {
     delete configData[key];
   }
@@ -172,6 +176,17 @@ describe('gcs-resumable-upload', () => {
     it('should set the predefinedAcl with private: true', () => {
       const up = upload({bucket: BUCKET, file: FILE, private: true});
       assert.strictEqual(up.predefinedAcl, 'private');
+    });
+
+    it('should create a ConfigStore instance', () => {
+      const up = upload({bucket: BUCKET, file: FILE});
+      assert.strictEqual(configData.packageName, 'gcs-resumable-upload');
+    });
+
+    it('should set the configPath', () => {
+      const configPath = '/custom/config/path';
+      const up = upload({bucket: BUCKET, file: FILE, configPath});
+      assert.deepStrictEqual(configData.config, {configPath});
     });
 
     it('should set numBytesWritten to 0', () => {


### PR DESCRIPTION
RE: #4

This introduces the `configPath` option. This allows a user to explicitly state where the ConfigStore config file will be stored.