### PR TITLE
feat: support apiEndpoint override

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "gcs-upload": "build/src/cli.js"
   },
   "scripts": {
-    "test": "nyc mocha build/test",
+    "test": "c8 mocha build/test",
     "lint": "gts check",
     "clean": "gts clean",
     "compile": "tsc -p .",
@@ -21,7 +21,7 @@
     "samples-test": "echo no samples 🤷‍♂️",
     "presystem-test": "npm run compile",
     "docs": "compodoc src/",
-    "docs-test": "linkinator docs -r --skip www.googleapis.com",
+    "docs-test": "linkinator docs -r",
     "predocs-test": "npm run docs"
   },
   "keywords": [
@@ -58,6 +58,7 @@
     "@types/node": "^10.3.0",
     "@types/pumpify": "^1.4.1",
     "assert-rejects": "^1.0.0",
+    "c8": "^5.0.1",
     "codecov": "^3.0.4",
     "gts": "^1.0.0",
     "intelli-espower-loader": "^1.0.1",
@@ -66,7 +67,6 @@
     "mocha": "^6.1.4",
     "mockery": "^2.1.0",
     "nock": "^10.0.0",
-    "nyc": "^14.0.0",
     "source-map-support": "^0.5.6",
     "typescript": "~3.5.0"
   }

--- a/test/test.ts
+++ b/test/test.ts
@@ -71,6 +71,8 @@ describe('gcs-resumable-upload', () => {
   const ORIGIN = '*';
   const PREDEFINED_ACL = 'authenticatedRead';
   const USER_PROJECT = 'user-project-id';
+  const API_ENDPOINT = 'fake.googleapis.com';
+  const BASE_URI = `https://${API_ENDPOINT}/upload/storage/v1/b`;
   let REQ_OPTS: GaxiosOptions;
   const keyFile = path.join(__dirname, '../../test/fixtures/keys.json');
 
@@ -93,6 +95,7 @@ describe('gcs-resumable-upload', () => {
       predefinedAcl: PREDEFINED_ACL,
       userProject: USER_PROJECT,
       authConfig: {keyFile},
+      apiEndpoint: API_ENDPOINT,
     });
   });
 
@@ -119,6 +122,11 @@ describe('gcs-resumable-upload', () => {
 
     it('should localize the generation', () => {
       assert.strictEqual(up.generation, GENERATION);
+    });
+
+    it('should localize the apiEndpoint', () => {
+      assert.strictEqual(up.apiEndpoint, API_ENDPOINT);
+      assert.strictEqual(up.baseURI, BASE_URI);
     });
 
     it('should localize the KMS key name', () => {
@@ -257,10 +265,7 @@ describe('gcs-resumable-upload', () => {
     it('should make the correct request', done => {
       up.makeRequest = async (reqOpts: GaxiosOptions) => {
         assert.strictEqual(reqOpts.method, 'POST');
-        assert.strictEqual(
-          reqOpts.url,
-          `https://www.googleapis.com/upload/storage/v1/b/${BUCKET}/o`
-        );
+        assert.strictEqual(reqOpts.url, `${BASE_URI}/${BUCKET}/o`);
         assert.deepStrictEqual(reqOpts.params, {
           predefinedAcl: up.predefinedAcl,
           name: FILE,


### PR DESCRIPTION
This does a few things:
- Adds the `apiEndpoint` config option, making it overridable
- Updates the default endpoint to use `storage.googleapis.com`
- Swaps out `nyc` for `c8` since coverage appeared to be broken