### PR TITLE
fix: expose 'Retry limit exceeded' server error message

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -566,7 +566,7 @@ export class Upload extends Pumpify {
         this.numRetries++;
         this.startUploading();
       } else {
-        this.destroy(new Error('Retry limit exceeded'));
+        this.destroy(new Error('Retry limit exceeded - ' + resp.data));
       }
       return false;
     }
@@ -577,7 +577,7 @@ export class Upload extends Pumpify {
         this.numRetries++;
         setTimeout(this.continueUploading.bind(this), waitTime);
       } else {
-        this.destroy(new Error('Retry limit exceeded'));
+        this.destroy(new Error('Retry limit exceeded - ' + resp.data));
       }
       return false;
     }

--- a/test/test.ts
+++ b/test/test.ts
@@ -1105,7 +1105,7 @@ describe('gcs-resumable-upload', () => {
     });
 
     describe('404', () => {
-      const RESP = {status: 404};
+      const RESP = {status: 404, data: 'error message from server'};
 
       it('should increase the retry count if less than limit', () => {
         assert.strictEqual(up.numRetries, 0);
@@ -1115,7 +1115,10 @@ describe('gcs-resumable-upload', () => {
 
       it('should destroy the stream if gte limit', done => {
         up.destroy = (err: Error) => {
-          assert.strictEqual(err.message, 'Retry limit exceeded');
+          assert.strictEqual(
+            err.message,
+            `Retry limit exceeded - ${RESP.data}`
+          );
           done();
         };
 
@@ -1134,7 +1137,7 @@ describe('gcs-resumable-upload', () => {
     });
 
     describe('500s', () => {
-      const RESP = {status: 500};
+      const RESP = {status: 500, data: 'error message from server'};
 
       it('should increase the retry count if less than limit', () => {
         assert.strictEqual(up.numRetries, 0);
@@ -1144,7 +1147,10 @@ describe('gcs-resumable-upload', () => {
 
       it('should destroy the stream if greater than limit', done => {
         up.destroy = (err: Error) => {
-          assert.strictEqual(err.message, 'Retry limit exceeded');
+          assert.strictEqual(
+            err.message,
+            `Retry limit exceeded - ${RESP.data}`
+          );
           done();
         };
 

--- a/test/test.ts
+++ b/test/test.ts
@@ -1182,7 +1182,10 @@ describe('gcs-resumable-upload', () => {
 
         up.on('error', (err: Error) => {
           assert.strictEqual(up.numRetries, 5);
-          assert.strictEqual(err.message, 'Retry limit exceeded');
+          assert.strictEqual(
+            err.message,
+            `Retry limit exceeded - ${RESP.data}`
+          );
           global.setTimeout = setTimeout;
           done();
         });


### PR DESCRIPTION
Towards finding the cause of googleapis/nodejs-storage/issues/675

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
