### PR TITLE
fix: make cache key unique by including generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,78 +40,105 @@ Oh, right. This module uses [google-auth-library](http://gitnpm.com/google-auth-
 
 ## API
 
-### {upload} = require('gcs-resumable-upload')
+```js
+const {gcsResumableUpload} = require('gcs-resumable-upload')
+const upload = gcsResumableUpload(config)
+```
+
+`upload` is an instance of [`Duplexify`](http://gitnpm.com/duplexify).
 
 ---
+<a name="methods"></a>
+### Methods
 
-#### upload(config)
+#### upload.createURI(callback)
 
-- Returns: [`Duplexify`](http://gitnpm.com/duplexify)
+##### callback(err, resumableURI)
 
+###### callback.err
+
+- Type: `Error`
+
+Invoked if the authorization failed or the request to start a resumable session failed.
+
+###### callback.resumableURI
+
+- Type: `String`
+
+The resumable upload session URI.
+
+
+#### upload.deleteConfig()
+
+This will remove the config data associated with the provided file.
+
+---
 <a name="config"></a>
-##### config
+### Configuration
+
+#### config
 
 - Type: `object`
 
 Configuration object.
 
-###### config.authClient
+##### config.authClient
 
 - Type: [`GoogleAuth`](http://gitnpm.com/google-auth-library)
 - *Optional*
 
 If you want to re-use an auth client from [google-auth-library](http://gitnpm.com/google-auth-library), pass an instance here.
 
-###### config.authConfig
+##### config.authConfig
 
 - Type: `object`
 - *Optional*
 
 See [`authConfig`](https://github.com/google/google-auth-library-nodejs/#choosing-the-correct-credential-type-automatically).
 
-###### config.bucket
+##### config.bucket
 
 - Type: `string`
 - **Required**
 
 The name of the destination bucket.
 
-###### config.configPath
+##### config.configPath
 
 - Type: `string`
 - *Optional*
 
 Where the gcs-resumable-upload configuration file should be stored on your system. This maps to the [configstore option by the same name](https://github.com/yeoman/configstore/tree/0df1ec950d952b1f0dfb39ce22af8e505dffc71a#configpath).
 
-###### config.file
+##### config.file
 
 - Type: `string`
 - **Required**
 
 The name of the destination file.
 
-###### config.generation
+##### config.generation
 
 - Type: `number`
 - *Optional*
 
 This will cause the upload to fail if the current generation of the remote object does not match the one provided here.
 
-###### config.key
+##### config.key
 
 - Type: `string|buffer`
 - *Optional*
 
 A [customer-supplied encryption key](https://cloud.google.com/storage/docs/encryption#customer-supplied).
 
-###### config.kmsKeyName
+##### config.kmsKeyName
 
 - Type: `string`
 - *Optional*
 
 Resource name of the Cloud KMS key, of the form `projects/my-project/locations/global/keyRings/my-kr/cryptoKeys/my-key`, that will be used to encrypt the object. Overrides the object metadata's `kms_key_name` value, if any.
 
-###### config.metadata
+##### config.metadata
 
 - Type: `object`
 - *Optional*
@@ -126,21 +153,21 @@ Set the length of the file being uploaded.
 
 Set the content type of the incoming data.
 
-###### config.offset
+##### config.offset
 
 - Type: `number`
 - *Optional*
 
 The starting byte of the upload stream, for [resuming an interrupted upload](https://cloud.google.com/storage/docs/json_api/v1/how-tos/resumable-upload#resume-upload).
 
-###### config.origin
+##### config.origin
 
 - Type: `string`
 - *Optional*
 
 Set an Origin header when creating the resumable upload URI.
 
-###### config.predefinedAcl
+##### config.predefinedAcl
 
 - Type: `string`
 - *Optional*
@@ -156,67 +183,71 @@ Acceptable values are:
   - **`projectPrivate`** - Object owner gets `OWNER` access, and project team members get access according to their roles.
   - **`publicRead`** - Object owner gets `OWNER` access, and `allUsers` get `READER` access.
 
-###### config.private
+##### config.private
 
 - Type: `boolean`
 - *Optional*
 
 Make the uploaded file private. (Alias for `config.predefinedAcl = 'private'`)
 
-###### config.public
+##### config.public
 
 - Type: `boolean`
 - *Optional*
 
 Make the uploaded file public. (Alias for `config.predefinedAcl = 'publicRead'`)
 
-###### config.uri
+##### config.uri
 
 - Type: `string`
 - *Optional*
 
 If you already have a resumable URI from a previously-created resumable upload, just pass it in here and we'll use that.
 
-###### config.userProject
+##### config.userProject
 
 - Type: `string`
 - *Optional*
 
 If the bucket being accessed has `requesterPays` functionality enabled, this can be set to control which project is billed for the access of this file.
 
---
+---
+<a name="events"></a>
+### Events
 
-#### Events
+#### .on('error', function (err) {})
 
-##### .on('error', function (err) {})
-
-###### err
+##### err
 
 - Type: `Error`
 
 Invoked if the authorization failed, the request failed, or the file wasn't successfully uploaded.
 
-##### .on('response', function (response) {})
+#### .on('response', function (response) {})
 
-###### resp
+##### resp
 
 - Type: `Object`
 
 The [response object from Gaxios](https://github.com/JustinBeckwith/gaxios/blob/88a47e000625d8192689acac5c40c0b1e1d963a2/src/gaxios.ts#L197-L203).
 
-###### metadata
+##### metadata
 
 - Type: `Object`
 
 The file's new metadata.
 
-##### .on('finish', function () {})
+#### .on('finish', function () {})
 
 The file was uploaded successfully.
 
 ---
+<a name="static-methods"></a>
+### Static Methods
 
-### {createURI} = require('gcs-resumable-upload);
+```js
+const {createURI} = require('gcs-resumable-upload')
+````
 
 #### createURI([config](#config), callback)
 

--- a/README.md
+++ b/README.md
@@ -40,105 +40,78 @@ Oh, right. This module uses [google-auth-library](http://gitnpm.com/google-auth-
 
 ## API
 
-```js
-const {gcsResumableUpload} = require('gcs-resumable-upload')
-const upload = gcsResumableUpload(config)
-```
-
-`upload` is an instance of [`Duplexify`](http://gitnpm.com/duplexify).
+### {upload} = require('gcs-resumable-upload')
 
 ---
-<a name="methods"></a>
-### Methods
 
-#### upload.createURI(callback)
+#### upload(config)
 
-##### callback(err, resumableURI)
+- Returns: [`Duplexify`](http://gitnpm.com/duplexify)
 
-###### callback.err
-
-- Type: `Error`
-
-Invoked if the authorization failed or the request to start a resumable session failed.
-
-###### callback.resumableURI
-
-- Type: `String`
-
-The resumable upload session URI.
-
-
-#### upload.deleteConfig()
-
-This will remove the config data associated with the provided file.
-
----
 <a name="config"></a>
-### Configuration
-
-#### config
+##### config
 
 - Type: `object`
 
 Configuration object.
 
-##### config.authClient
+###### config.authClient
 
 - Type: [`GoogleAuth`](http://gitnpm.com/google-auth-library)
 - *Optional*
 
 If you want to re-use an auth client from [google-auth-library](http://gitnpm.com/google-auth-library), pass an instance here.
 
-##### config.authConfig
+###### config.authConfig
 
 - Type: `object`
 - *Optional*
 
 See [`authConfig`](https://github.com/google/google-auth-library-nodejs/#choosing-the-correct-credential-type-automatically).
 
-##### config.bucket
+###### config.bucket
 
 - Type: `string`
 - **Required**
 
 The name of the destination bucket.
 
-##### config.configPath
+###### config.configPath
 
 - Type: `string`
 - *Optional*
 
 Where the gcs-resumable-upload configuration file should be stored on your system. This maps to the [configstore option by the same name](https://github.com/yeoman/configstore/tree/0df1ec950d952b1f0dfb39ce22af8e505dffc71a#configpath).
 
-##### config.file
+###### config.file
 
 - Type: `string`
 - **Required**
 
 The name of the destination file.
 
-##### config.generation
+###### config.generation
 
 - Type: `number`
 - *Optional*
 
 This will cause the upload to fail if the current generation of the remote object does not match the one provided here.
 
-##### config.key
+###### config.key
 
 - Type: `string|buffer`
 - *Optional*
 
 A [customer-supplied encryption key](https://cloud.google.com/storage/docs/encryption#customer-supplied).
 
-##### config.kmsKeyName
+###### config.kmsKeyName
 
 - Type: `string`
 - *Optional*
 
 Resource name of the Cloud KMS key, of the form `projects/my-project/locations/global/keyRings/my-kr/cryptoKeys/my-key`, that will be used to encrypt the object. Overrides the object metadata's `kms_key_name` value, if any.
 
-##### config.metadata
+###### config.metadata
 
 - Type: `object`
 - *Optional*
@@ -153,21 +126,21 @@ Set the length of the file being uploaded.
 
 Set the content type of the incoming data.
 
-##### config.offset
+###### config.offset
 
 - Type: `number`
 - *Optional*
 
 The starting byte of the upload stream, for [resuming an interrupted upload](https://cloud.google.com/storage/docs/json_api/v1/how-tos/resumable-upload#resume-upload).
 
-##### config.origin
+###### config.origin
 
 - Type: `string`
 - *Optional*
 
 Set an Origin header when creating the resumable upload URI.
 
-##### config.predefinedAcl
+###### config.predefinedAcl
 
 - Type: `string`
 - *Optional*
@@ -183,71 +156,67 @@ Acceptable values are:
   - **`projectPrivate`** - Object owner gets `OWNER` access, and project team members get access according to their roles.
   - **`publicRead`** - Object owner gets `OWNER` access, and `allUsers` get `READER` access.
 
-##### config.private
+###### config.private
 
 - Type: `boolean`
 - *Optional*
 
 Make the uploaded file private. (Alias for `config.predefinedAcl = 'private'`)
 
-##### config.public
+###### config.public
 
 - Type: `boolean`
 - *Optional*
 
 Make the uploaded file public. (Alias for `config.predefinedAcl = 'publicRead'`)
 
-##### config.uri
+###### config.uri
 
 - Type: `string`
 - *Optional*
 
 If you already have a resumable URI from a previously-created resumable upload, just pass it in here and we'll use that.
 
-##### config.userProject
+###### config.userProject
 
 - Type: `string`
 - *Optional*
 
 If the bucket being accessed has `requesterPays` functionality enabled, this can be set to control which project is billed for the access of this file.
 
----
-<a name="events"></a>
-### Events
+--
 
-#### .on('error', function (err) {})
+#### Events
 
-##### err
+##### .on('error', function (err) {})
+
+###### err
 
 - Type: `Error`
 
 Invoked if the authorization failed, the request failed, or the file wasn't successfully uploaded.
 
-#### .on('response', function (response) {})
+##### .on('response', function (response) {})
 
-##### resp
+###### resp
 
 - Type: `Object`
 
 The [response object from Gaxios](https://github.com/JustinBeckwith/gaxios/blob/88a47e000625d8192689acac5c40c0b1e1d963a2/src/gaxios.ts#L197-L203).
 
-##### metadata
+###### metadata
 
 - Type: `Object`
 
 The file's new metadata.
 
-#### .on('finish', function () {})
+##### .on('finish', function () {})
 
 The file was uploaded successfully.
 
 ---
-<a name="static-methods"></a>
-### Static Methods
 
-```js
-const {createURI} = require('gcs-resumable-upload')
-````
+### {createURI} = require('gcs-resumable-upload);
 
 #### createURI([config](#config), callback)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -561,7 +561,7 @@ export class Upload extends Pumpify {
     this.configStore.set(this.cacheKey, props);
   }
 
-  deleteConfig() {
+  private deleteConfig() {
     this.configStore.delete(this.cacheKey);
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -562,7 +562,7 @@ export class Upload extends Pumpify {
   }
 
   deleteConfig() {
-    this.configStore.delete([this.bucket, this.file].join('/'));
+    this.configStore.delete(this.cacheKey);
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -154,6 +154,7 @@ export class Upload extends Pumpify {
   apiEndpoint: string;
   authConfig?: {scopes?: string[]};
   authClient: GoogleAuth;
+  cacheKey: string;
   generation?: number;
   key?: string | Buffer;
   kmsKeyName?: string;
@@ -202,6 +203,13 @@ export class Upload extends Pumpify {
 
     this.apiEndpoint = cfg.apiEndpoint || 'storage.googleapis.com';
     this.bucket = cfg.bucket;
+
+    const cacheKeyElements = [cfg.bucket, cfg.file];
+    if (cfg.generation) {
+      cacheKeyElements.push(`${cfg.generation}`);
+    }
+    this.cacheKey = cacheKeyElements.join('/');
+
     this.file = cfg.file;
     this.generation = cfg.generation;
     this.kmsKeyName = cfg.kmsKeyName;
@@ -544,17 +552,17 @@ export class Upload extends Pumpify {
   }
 
   private get(prop: string) {
-    const store = this.configStore.get([this.bucket, this.file].join('/'));
+    const store = this.configStore.get(this.cacheKey);
     return store && store[prop];
   }
 
   // tslint:disable-next-line no-any
   private set(props: any) {
-    this.configStore.set([this.bucket, this.file].join('/'), props);
+    this.configStore.set(this.cacheKey, props);
   }
 
-  private deleteConfig() {
-    this.configStore.delete([this.bucket, this.file].join('/'));
+  deleteConfig() {
+    this.configStore.delete(this.cacheKey);
   }
 
   /**

--- a/test/test.ts
+++ b/test/test.ts
@@ -116,8 +116,24 @@ describe('gcs-resumable-upload', () => {
       }, /A bucket and file name are required/);
     });
 
-    it('should localize the bucket and file', () => {
+    it('should localize the bucket', () => {
       assert.strictEqual(up.bucket, BUCKET);
+    });
+
+    it('should localize the cacheKey', () => {
+      assert.strictEqual(up.cacheKey, [BUCKET, FILE, GENERATION].join('/'));
+    });
+
+    it('should not include a generation in the cacheKey if it was not set', () => {
+      const up = upload({
+        bucket: BUCKET,
+        file: FILE,
+      });
+
+      assert.strictEqual(up.cacheKey, [BUCKET, FILE].join('/'));
+    });
+
+    it('should localize the file', () => {
       assert.strictEqual(up.file, FILE);
     });
 
@@ -225,7 +241,7 @@ describe('gcs-resumable-upload', () => {
       assert.strictEqual(upWithUri.uriProvidedManually, true);
       assert.strictEqual(upWithUri.uri, uri);
 
-      configData[[BUCKET, FILE].join('/')] = {uri: 'fake-uri'};
+      configData[`${BUCKET}/${FILE}`] = {uri: 'fake-uri'};
       const up = upload({bucket: BUCKET, file: FILE});
       assert.strictEqual(up.uriProvidedManually, false);
       assert.strictEqual(up.uri, 'fake-uri');
@@ -1056,8 +1072,7 @@ describe('gcs-resumable-upload', () => {
       const value = 'abc';
       up.configStore = {
         get(name: string) {
-          const actualKey = [up.bucket, up.file].join('/');
-          assert.strictEqual(name, actualKey);
+          assert.strictEqual(name, up.cacheKey);
           const obj: {[i: string]: string} = {};
           obj[prop] = value;
           return obj;
@@ -1072,8 +1087,7 @@ describe('gcs-resumable-upload', () => {
       const props = {setting: true};
       up.configStore = {
         set(name: string, prps: {}) {
-          const actualKey = [up.bucket, up.file].join('/');
-          assert.strictEqual(name, actualKey);
+          assert.strictEqual(name, up.cacheKey);
           assert.strictEqual(prps, props);
           done();
         },
@@ -1088,8 +1102,7 @@ describe('gcs-resumable-upload', () => {
 
       up.configStore = {
         delete(name: string) {
-          const actualKey = [up.bucket, up.file].join('/');
-          assert.strictEqual(name, actualKey);
+          assert.strictEqual(name, up.cacheKey);
           done();
         },
       };


### PR DESCRIPTION
Fixes https://github.com/googleapis/nodejs-storage/issues/217

When a user attempts an upload, this lib checks a cache file to see if it should resume a previously-failed attempt, or start a new one. This system previously failed if a user started an upload, it failed, then they tried again with a new generation. That was because the cache file persisted data about each file based on a key in the format of "bucketName/fileName". Now, it will be "bucketName/fileName/generation".