### PR TITLE
fix: handle a `0` generation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -205,7 +205,7 @@ export class Upload extends Pumpify {
     this.bucket = cfg.bucket;
 
     const cacheKeyElements = [cfg.bucket, cfg.file];
-    if (!isNaN(cfg.generation!)) {
+    if (typeof cfg.generation === 'number') {
       cacheKeyElements.push(`${cfg.generation}`);
     }
     this.cacheKey = cacheKeyElements.join('/');

--- a/src/index.ts
+++ b/src/index.ts
@@ -205,7 +205,7 @@ export class Upload extends Pumpify {
     this.bucket = cfg.bucket;
 
     const cacheKeyElements = [cfg.bucket, cfg.file];
-    if (cfg.generation) {
+    if (!isNaN(cfg.generation!)) {
       cacheKeyElements.push(`${cfg.generation}`);
     }
     this.cacheKey = cacheKeyElements.join('/');

--- a/test/test.ts
+++ b/test/test.ts
@@ -124,6 +124,24 @@ describe('gcs-resumable-upload', () => {
       assert.strictEqual(up.cacheKey, [BUCKET, FILE, GENERATION].join('/'));
     });
 
+    it('should include ZERO generation value in the cacheKey', () => {
+      const upWithZeroGeneration = upload({
+        bucket: BUCKET,
+        file: FILE,
+        generation: 0,
+        metadata: METADATA,
+        origin: ORIGIN,
+        predefinedAcl: PREDEFINED_ACL,
+        userProject: USER_PROJECT,
+        authConfig: {keyFile},
+        apiEndpoint: API_ENDPOINT,
+      });
+      assert.strictEqual(
+        upWithZeroGeneration.cacheKey,
+        [BUCKET, FILE, 0].join('/')
+      );
+    });
+
     it('should not include a generation in the cacheKey if it was not set', () => {
       const up = upload({
         bucket: BUCKET,


### PR DESCRIPTION
Fixes #246 

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
