### PR TITLE
fix: let gaxios handle API errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "linkinator": "^1.5.0",
     "mocha": "^6.1.4",
     "mockery": "^2.1.0",
-    "nock": "^10.0.0",
+    "nock": "^11.0.0",
     "sinon": "^7.3.2",
     "source-map-support": "^0.5.6",
     "typescript": "~3.5.0"

--- a/src/index.ts
+++ b/src/index.ts
@@ -86,7 +86,7 @@ export interface UploadConfig {
   /**
    * Any metadata you wish to set on the object.
    */
-  metadata?: any;
+  metadata?: ConfigMetadata;
 
   /**
    * The starting byte of the upload stream, for resuming an interrupted upload.
@@ -136,6 +136,21 @@ export interface UploadConfig {
   userProject?: string;
 }
 
+export interface ConfigMetadata {
+  // tslint:disable-next-line no-any
+  [key: string]: any;
+
+  /**
+   * Set the length of the file being uploaded.
+   */
+  contentLength?: number;
+
+  /**
+   * Set the content type of the incoming data.
+   */
+  contentType?: string;
+}
+
 export class Upload extends Pumpify {
   bucket: string;
   file: string;
@@ -146,7 +161,7 @@ export class Upload extends Pumpify {
   generation?: number;
   key?: string | Buffer;
   kmsKeyName?: string;
-  metadata: any;
+  metadata: ConfigMetadata;
   offset?: number;
   origin?: string;
   predefinedAcl?:

--- a/src/index.ts
+++ b/src/index.ts
@@ -86,7 +86,7 @@ export interface UploadConfig {
   /**
    * Any metadata you wish to set on the object.
    */
-  metadata?: ConfigMetadata;
+  metadata?: object;
 
   /**
    * The starting byte of the upload stream, for resuming an interrupted upload.
@@ -136,18 +136,6 @@ export interface UploadConfig {
   userProject?: string;
 }
 
-export interface ConfigMetadata extends Object {
-  /**
-   * Set the length of the file being uploaded.
-   */
-  contentLength?: number;
-
-  /**
-   * Set the content type of the incoming data.
-   */
-  contentType?: string;
-}
-
 export class Upload extends Pumpify {
   bucket: string;
   file: string;
@@ -158,7 +146,7 @@ export class Upload extends Pumpify {
   generation?: number;
   key?: string | Buffer;
   kmsKeyName?: string;
-  metadata: ConfigMetadata;
+  metadata: object;
   offset?: number;
   origin?: string;
   predefinedAcl?:

--- a/src/index.ts
+++ b/src/index.ts
@@ -86,7 +86,7 @@ export interface UploadConfig {
   /**
    * Any metadata you wish to set on the object.
    */
-  metadata?: object;
+  metadata?: any;
 
   /**
    * The starting byte of the upload stream, for resuming an interrupted upload.
@@ -146,7 +146,7 @@ export class Upload extends Pumpify {
   generation?: number;
   key?: string | Buffer;
   kmsKeyName?: string;
-  metadata: object;
+  metadata: any;
   offset?: number;
   origin?: string;
   predefinedAcl?:

--- a/test/test.ts
+++ b/test/test.ts
@@ -841,13 +841,25 @@ describe('gcs-resumable-upload', () => {
       scopes.forEach(x => x.done());
     });
 
-    it('should execute the callback with error & response if one occurred', async () => {
-      const scope = mockAuthorizeRequest(500, ':(');
-      await assertRejects(
-        up.makeRequest({}),
-        /Request failed with status code 500/
-      );
-      scope.done();
+    it('should set validate status', done => {
+      up.authClient = {
+        request: (reqOpts: GaxiosOptions) => {
+          assert.strictEqual(reqOpts.validateStatus!(100), false);
+          assert.strictEqual(reqOpts.validateStatus!(199), false);
+          assert.strictEqual(reqOpts.validateStatus!(300), false);
+          assert.strictEqual(reqOpts.validateStatus!(400), false);
+          assert.strictEqual(reqOpts.validateStatus!(500), false);
+
+          assert.strictEqual(reqOpts.validateStatus!(200), true);
+          assert.strictEqual(reqOpts.validateStatus!(299), true);
+          assert.strictEqual(reqOpts.validateStatus!(308), true);
+
+          done();
+
+          return {};
+        },
+      };
+      up.makeRequest(REQ_OPTS);
     });
 
     it('should make the correct request', async () => {
@@ -861,17 +873,6 @@ describe('gcs-resumable-upload', () => {
       scopes.forEach(x => x.done());
       assert.strictEqual(res.config.url, REQ_OPTS.url + queryPath);
       assert.deepStrictEqual(res.headers, {});
-    });
-
-    it('should execute the callback with error & response', async () => {
-      const response = {body: 'wooo'};
-      mockAuthorizeRequest();
-      const scope = nock(REQ_OPTS.url!)
-        .get(queryPath)
-        .reply(500, response.body);
-      const resp = await up.makeRequest(REQ_OPTS);
-      assert.strictEqual(resp.data, response.body);
-      scope.done();
     });
 
     it('should execute the callback with a body error & response', async () => {


### PR DESCRIPTION
Fixes https://github.com/googleapis/nodejs-storage/issues/811

When we call the API to query the status of a resumable upload operation, we have been letting gaxios consider all API responses a success. This change makes sure that only the 308 status (resumable upload incomplete) is excused, since we handle that from this library.