### PR TITLE
feat: support all query parameters during URI creation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -38,20 +38,22 @@ export interface Encryption {
   hash: {};
 }
 
-export interface QueryParameters {
-  contentEncoding?: string;
-  ifGenerationMatch?: number;
-  ifGenerationNotMatch?: number;
-  ifMetagenerationMatch?: number;
-  ifMetagenerationNotMatch?: number;
-  kmsKeyName?: number;
-  predefinedAcl?:
+export type PredefinedAcl =
     | 'authenticatedRead'
     | 'bucketOwnerFullControl'
     | 'bucketOwnerRead'
     | 'private'
     | 'projectPrivate'
     | 'publicRead';
+
+export interface QueryParameters {
+  contentEncoding?: string;
+  ifGenerationMatch?: number;
+  ifGenerationNotMatch?: number;
+  ifMetagenerationMatch?: number;
+  ifMetagenerationNotMatch?: number;
+  kmsKeyName?: string;
+  predefinedAcl?: PredefinedAcl;
   projection?: 'full' | 'noAcl';
   userProject?: string;
 }
@@ -136,7 +138,7 @@ export interface UploadConfig {
   /**
    * Apply a predefined set of access controls to the created file.
    */
-  predefinedAcl?: QueryParameters['predefinedAcl'];
+  predefinedAcl?: PredefinedAcl;
 
   /**
    * Make the uploaded file private. (Alias for config.predefinedAcl =
@@ -192,7 +194,7 @@ export class Upload extends Pumpify {
   offset?: number;
   origin?: string;
   params: QueryParameters;
-  predefinedAcl?: QueryParameters['predefinedAcl'];
+  predefinedAcl?: PredefinedAcl;
   private?: boolean;
   public?: boolean;
   uri?: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,12 +39,12 @@ export interface Encryption {
 }
 
 export type PredefinedAcl =
-    | 'authenticatedRead'
-    | 'bucketOwnerFullControl'
-    | 'bucketOwnerRead'
-    | 'private'
-    | 'projectPrivate'
-    | 'publicRead';
+  | 'authenticatedRead'
+  | 'bucketOwnerFullControl'
+  | 'bucketOwnerRead'
+  | 'private'
+  | 'projectPrivate'
+  | 'publicRead';
 
 export interface QueryParameters {
   contentEncoding?: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -96,7 +96,7 @@ export interface UploadConfig {
    * This will cause the upload to fail if the current generation of the remote
    * object does not match the one provided here.
    */
-  generation?: QueryParameters['ifGenerationMatch'];
+  generation?: number;
 
   /**
    * A customer-supplied encryption key. See
@@ -110,7 +110,7 @@ export interface UploadConfig {
    * that will be used to encrypt the object. Overrides the object metadata's
    * `kms_key_name` value, if any.
    */
-  kmsKeyName?: QueryParameters['kmsKeyName'];
+  kmsKeyName?: string;
 
   /**
    * Any metadata you wish to set on the object.
@@ -162,7 +162,7 @@ export interface UploadConfig {
    * If the bucket being accessed has requesterPays functionality enabled, this
    * can be set to control which project is billed for the access of this file.
    */
-  userProject?: QueryParameters['userProject'];
+  userProject?: string;
 }
 
 export interface ConfigMetadata {
@@ -189,7 +189,7 @@ export class Upload extends Pumpify {
   cacheKey: string;
   generation?: number;
   key?: string | Buffer;
-  kmsKeyName?: QueryParameters['kmsKeyName'];
+  kmsKeyName?: string;
   metadata: ConfigMetadata;
   offset?: number;
   origin?: string;
@@ -198,7 +198,7 @@ export class Upload extends Pumpify {
   private?: boolean;
   public?: boolean;
   uri?: string;
-  userProject?: QueryParameters['userProject'];
+  userProject?: string;
   encryption?: Encryption;
   configStore: ConfigStore;
   uriProvidedManually: boolean;

--- a/test/test.ts
+++ b/test/test.ts
@@ -79,6 +79,7 @@ describe('gcs-resumable-upload', () => {
   const GENERATION = Date.now();
   const METADATA = {contentLength: 1024, contentType: 'application/json'};
   const ORIGIN = '*';
+  const PARAMS = {ifMetagenerationNotMatch: 3};
   const PREDEFINED_ACL = 'authenticatedRead';
   const USER_PROJECT = 'user-project-id';
   const API_ENDPOINT = 'fake.googleapis.com';
@@ -102,6 +103,7 @@ describe('gcs-resumable-upload', () => {
       generation: GENERATION,
       metadata: METADATA,
       origin: ORIGIN,
+      params: PARAMS,
       predefinedAcl: PREDEFINED_ACL,
       userProject: USER_PROJECT,
       authConfig: {keyFile},
@@ -195,6 +197,10 @@ describe('gcs-resumable-upload', () => {
 
     it('should localize the origin', () => {
       assert.strictEqual(up.origin, ORIGIN);
+    });
+
+    it('should localize the params', () => {
+      assert.strictEqual(up.params, PARAMS);
     });
 
     it('should localize userProject', () => {
@@ -315,6 +321,7 @@ describe('gcs-resumable-upload', () => {
           name: FILE,
           uploadType: 'resumable',
           ifGenerationMatch: GENERATION,
+          ifMetagenerationNotMatch: PARAMS.ifMetagenerationNotMatch,
         });
         assert.strictEqual(reqOpts.data, up.metadata);
         done();


### PR DESCRIPTION
Fixes #7

This allows the user to pass in all of the available query parameter options allowed by the API: https://cloud.google.com/storage/docs/json_api/v1/objects/insert#parameters

Currently, we alias only the ones we need from @google-cloud/storage. This PR keeps those aliases, but also accepts them through a new `config.params` property.