### PR TITLE
test: handle flaky upstream failures

### DIFF
--- a/system-test/kitchen.ts
+++ b/system-test/kitchen.ts
@@ -21,6 +21,7 @@ import * as path from 'path';
 import * as os from 'os';
 import {Readable} from 'stream';
 import {createURI, ErrorWithCode, upload} from '../src';
+import {delay} from './util';
 
 const bucketName = process.env.BUCKET_NAME || 'gcs-resumable-upload-test';
 const fileName = '20MB.zip';
@@ -51,52 +52,59 @@ describe('end to end', () => {
       });
   });
 
-  it('should resume an interrupted upload', done => {
-    fs.stat(fileName, (err, fd) => {
-      assert.ifError(err);
+  it('should resume an interrupted upload', function (done) {
+    this.retries(3);
+    delay(this.test, () => {
+      // If we've retried, delay.
+      fs.stat(fileName, (err, fd) => {
+        assert.ifError(err);
 
-      const size = fd.size;
+        const size = fd.size;
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      type DoUploadCallback = (...args: any[]) => void;
-      const doUpload = (
-        opts: {interrupt?: boolean},
-        callback: DoUploadCallback
-      ) => {
-        let sizeStreamed = 0;
-        let destroyed = false;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        type DoUploadCallback = (...args: any[]) => void;
+        const doUpload = (
+          opts: {interrupt?: boolean},
+          callback: DoUploadCallback
+        ) => {
+          let sizeStreamed = 0;
+          let destroyed = false;
 
-        const ws = upload({
-          bucket: bucketName,
-          file: fileName,
-          metadata: {contentType: 'image/jpg'},
-        });
+          const ws = upload({
+            bucket: bucketName,
+            file: fileName,
+            metadata: {contentType: 'image/jpg'},
+          });
 
-        fs.createReadStream(fileName)
-          .on('error', callback)
-          .on('data', function (this: Readable, chunk) {
-            sizeStreamed += chunk.length;
+          fs.createReadStream(fileName)
+            .on('error', callback)
+            .on('data', function (this: Readable, chunk) {
+              sizeStreamed += chunk.length;
 
-            if (!destroyed && opts.interrupt && sizeStreamed >= size / 2) {
-              // stop sending data half way through
-              destroyed = true;
-              this.destroy();
-              process.nextTick(() => ws.destroy(new Error('Interrupted')));
+              if (!destroyed && opts.interrupt && sizeStreamed >= size / 2) {
+                // stop sending data half way through
+                destroyed = true;
+                this.destroy();
+                process.nextTick(() => ws.destroy(new Error('Interrupted')));
+              }
+            })
+            .pipe(ws)
+            .on('error', callback)
+            .on('metadata', callback.bind(null, null));
+        };
+
+        doUpload({interrupt: true}, (err: Error) => {
+          assert.strictEqual(err.message, 'Interrupted');
+
+          doUpload(
+            {interrupt: false},
+            (err: Error, metadata: {size: number}) => {
+              assert.ifError(err);
+              assert.strictEqual(metadata.size, size);
+              assert.strictEqual(typeof metadata.size, 'number');
+              done();
             }
-          })
-          .pipe(ws)
-          .on('error', callback)
-          .on('metadata', callback.bind(null, null));
-      };
-
-      doUpload({interrupt: true}, (err: Error) => {
-        assert.strictEqual(err.message, 'Interrupted');
-
-        doUpload({interrupt: false}, (err: Error, metadata: {size: number}) => {
-          assert.ifError(err);
-          assert.strictEqual(metadata.size, size);
-          assert.strictEqual(typeof metadata.size, 'number');
-          done();
+          );
         });
       });
     });

--- a/system-test/kitchen.ts
+++ b/system-test/kitchen.ts
@@ -21,7 +21,7 @@ import * as path from 'path';
 import * as os from 'os';
 import {Readable} from 'stream';
 import {createURI, ErrorWithCode, upload} from '../src';
-import {delay} from './util';
+import delay from './util';
 
 const bucketName = process.env.BUCKET_NAME || 'gcs-resumable-upload-test';
 const fileName = '20MB.zip';
@@ -52,9 +52,11 @@ describe('end to end', () => {
       });
   });
 
+  let retries = 0;
   it('should resume an interrupted upload', function (done) {
     this.retries(3);
-    delay(this.test, () => {
+    delay(this.test!.title, retries, () => {
+      retries++;
       // If we've retried, delay.
       fs.stat(fileName, (err, fd) => {
         assert.ifError(err);

--- a/system-test/util.ts
+++ b/system-test/util.ts
@@ -1,0 +1,26 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// ML tests frequently run into concurrency and quota issues, for which
+// retrying with a backoff is a good strategy:
+module.exports = {
+  async delay(test, done) {
+    const retries = test.currentRetry();
+    if (retries === 0) return done(); // no retry on the first failure.
+    // see: https://cloud.google.com/storage/docs/exponential-backoff:
+    const ms = Math.pow(2, retries) * 1000 + Math.random() * 2000;
+    console.info(`retrying "${test.title}" in ${ms}ms`);
+    setTimeout(done, ms);
+  },
+};

--- a/system-test/util.ts
+++ b/system-test/util.ts
@@ -11,16 +11,14 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
-// ML tests frequently run into concurrency and quota issues, for which
-// retrying with a backoff is a good strategy:
-module.exports = {
-  async delay(test, done) {
-    const retries = test.currentRetry();
-    if (retries === 0) return done(); // no retry on the first failure.
-    // see: https://cloud.google.com/storage/docs/exponential-backoff:
-    const ms = Math.pow(2, retries) * 1000 + Math.random() * 2000;
-    console.info(`retrying "${test.title}" in ${ms}ms`);
-    setTimeout(done, ms);
-  },
-};
+export default async function delay(
+  title: string,
+  retries: number,
+  done: Function
+) {
+  if (retries === 0) return done(); // no retry on the first failure.
+  // see: https://cloud.google.com/storage/docs/exponential-backoff:
+  const ms = Math.pow(2, retries) * 1000 + Math.random() * 2000;
+  console.info(`retrying "${title}" in ${ms}ms`);
+  setTimeout(done, ms);
+}


### PR DESCRIPTION
`should resume an interrupted upload` appears to sometimes fail due to upstream API issues.