### PR TITLE
feat: allow user-specified protocol for options.apiEndpoint

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -228,7 +228,7 @@ export class Upload extends Pumpify {
     ];
     this.authClient = cfg.authClient || new GoogleAuth(cfg.authConfig);
 
-    this.apiEndpoint = sanitize(cfg.apiEndpoint) || 'storage.googleapis.com';
+    this.apiEndpoint = sanitize(cfg.apiEndpoint) || 'https://storage.googleapis.com';
     this.bucket = cfg.bucket;
 
     const cacheKeyElements = [cfg.bucket, cfg.file];

--- a/src/index.ts
+++ b/src/index.ts
@@ -209,7 +209,7 @@ export class Upload extends Pumpify {
   private offsetStream?: PassThrough;
 
   private get baseURI(): string {
-    return `https://${this.apiEndpoint}/upload/storage/v1/b`;
+    return `${this.apiEndpoint}/upload/storage/v1/b`;
   }
 
   constructor(cfg: UploadConfig) {
@@ -228,7 +228,7 @@ export class Upload extends Pumpify {
     ];
     this.authClient = cfg.authClient || new GoogleAuth(cfg.authConfig);
 
-    this.apiEndpoint = cfg.apiEndpoint || 'storage.googleapis.com';
+    this.apiEndpoint = sanitize(cfg.apiEndpoint) || 'storage.googleapis.com';
     this.bucket = cfg.bucket;
 
     const cacheKeyElements = [cfg.bucket, cfg.file];
@@ -626,6 +626,14 @@ export class Upload extends Pumpify {
     this.emit('response', resp);
     return true;
   }
+}
+
+/*
+ * Prepend protocol to url if not present.
+ */
+const sanitize = (url: string|undefined): string|void => {
+  if (url)
+    return url.match(/^https?:\/\//) ? url : `https://${url}`;
 }
 
 export function upload(cfg: UploadConfig) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -228,7 +228,8 @@ export class Upload extends Pumpify {
     ];
     this.authClient = cfg.authClient || new GoogleAuth(cfg.authConfig);
 
-    this.apiEndpoint = sanitize(cfg.apiEndpoint) || 'https://storage.googleapis.com';
+    this.apiEndpoint =
+      sanitize(cfg.apiEndpoint) || 'https://storage.googleapis.com';
     this.bucket = cfg.bucket;
 
     const cacheKeyElements = [cfg.bucket, cfg.file];

--- a/src/index.ts
+++ b/src/index.ts
@@ -631,10 +631,9 @@ export class Upload extends Pumpify {
 /*
  * Prepend protocol to url if not present.
  */
-const sanitize = (url: string|undefined): string|void => {
-  if (url)
-    return url.match(/^https?:\/\//) ? url : `https://${url}`;
-}
+const sanitize = (url: string | undefined): string | void => {
+  if (url) return url.match(/^https?:\/\//) ? url : `https://${url}`;
+};
 
 export function upload(cfg: UploadConfig) {
   return new Upload(cfg);

--- a/test/test.ts
+++ b/test/test.ts
@@ -180,8 +180,8 @@ describe('gcs-resumable-upload', () => {
       const up = upload({
         bucket: BUCKET,
         file: FILE,
-        apiEndpoint: 'fake.googleapis.com' 
-      })
+        apiEndpoint: 'fake.googleapis.com',
+      });
       assert.strictEqual(up.apiEndpoint, API_ENDPOINT);
       assert.strictEqual(up.baseURI, BASE_URI);
     });

--- a/test/test.ts
+++ b/test/test.ts
@@ -83,8 +83,8 @@ describe('gcs-resumable-upload', () => {
   const PARAMS = {ifMetagenerationNotMatch: 3};
   const PREDEFINED_ACL = 'authenticatedRead';
   const USER_PROJECT = 'user-project-id';
-  const API_ENDPOINT = 'fake.googleapis.com';
-  const BASE_URI = `https://${API_ENDPOINT}/upload/storage/v1/b`;
+  const API_ENDPOINT = 'https://fake.googleapis.com';
+  const BASE_URI = `${API_ENDPOINT}/upload/storage/v1/b`;
   let REQ_OPTS: GaxiosOptions;
   const keyFile = path.join(__dirname, '../../test/fixtures/keys.json');
 
@@ -172,6 +172,16 @@ describe('gcs-resumable-upload', () => {
     });
 
     it('should localize the apiEndpoint', () => {
+      assert.strictEqual(up.apiEndpoint, API_ENDPOINT);
+      assert.strictEqual(up.baseURI, BASE_URI);
+    });
+
+    it('should prepend https:// to apiEndpoint if not present', () => {
+      const up = upload({
+        bucket: BUCKET,
+        file: FILE,
+        apiEndpoint: 'fake.googleapis.com' 
+      })
       assert.strictEqual(up.apiEndpoint, API_ENDPOINT);
       assert.strictEqual(up.baseURI, BASE_URI);
     });


### PR DESCRIPTION
Required for https://github.com/googleapis/nodejs-storage/pull/1161.

This allow user to specify a protocol before `apiEndpoint`, for use with a local emulator etc..
`new upload({apiEndpoint: 'http://fake.googleapis.com'});`

protocol-less apiEndpoint is still accepted (which will default to appending `https://` in front of the url).

This allows us to support the same behaviour in nodejs-storage: https://github.com/googleapis/nodejs-storage/pull/1161