### PR TITLE
feat: allow custom request options

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,25 @@ The name of the destination bucket.
 
 Where the gcs-resumable-upload configuration file should be stored on your system. This maps to the [configstore option by the same name](https://github.com/yeoman/configstore/tree/0df1ec950d952b1f0dfb39ce22af8e505dffc71a#configpath).
 
+##### config.customRequestOptions
+
+- Type: `object`
+- *Optional*
+
+For each API request we send, you may specify custom request options that we'll add onto the request. The request options follow the node-fetch API: https://github.com/node-fetch/node-fetch#options.
+
+For example, to set your own HTTP headers:
+
+```js
+const stream = upload({
+  customRequestOptions: {
+    headers: {
+      'X-My-Header': 'My custom value',
+    },
+  },
+})
+```
+
 ##### config.file
 
 - Type: `string`

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Where the gcs-resumable-upload configuration file should be stored on your syste
 - Type: `object`
 - *Optional*
 
-For each API request we send, you may specify custom request options that we'll add onto the request. The request options follow the node-fetch API: https://github.com/node-fetch/node-fetch#options.
+For each API request we send, you may specify custom request options that we'll add onto the request. The request options follow the gaxios API: https://github.com/googleapis/gaxios#request-options.
 
 For example, to set your own HTTP headers:
 

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
   "devDependencies": {
     "@compodoc/compodoc": "^1.1.7",
     "@types/configstore": "^4.0.0",
+    "@types/extend": "^3.0.1",
     "@types/is-stream": "^1.1.0",
     "@types/mocha": "^7.0.0",
     "@types/mockery": "^1.4.29",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   "dependencies": {
     "abort-controller": "^3.0.0",
     "configstore": "^5.0.0",
+    "extend": "^3.0.2",
     "gaxios": "^3.0.0",
     "google-auth-library": "^6.0.0",
     "pumpify": "^2.0.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -97,10 +97,10 @@ export interface UploadConfig {
 
   /**
    * For each API request we send, you may specify custom request options that
-   * we'll add onto the request. The request options follow the node-fetch API:
-   * https://github.com/node-fetch/node-fetch#options.
+   * we'll add onto the request. The request options follow the gaxios API:
+   * https://github.com/googleapis/gaxios#request-options.
    */
-  customRequestOptions?: object;
+  customRequestOptions?: GaxiosOptions;
 
   /**
    * This will cause the upload to fail if the current generation of the remote
@@ -198,7 +198,7 @@ export class Upload extends Pumpify {
   authConfig?: {scopes?: string[]};
   authClient: GoogleAuth;
   cacheKey: string;
-  customRequestOptions: object;
+  customRequestOptions: GaxiosOptions;
   generation?: number;
   key?: string | Buffer;
   kmsKeyName?: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@
 import AbortController from 'abort-controller';
 import * as ConfigStore from 'configstore';
 import {createHash} from 'crypto';
+const extend = require('extend');
 import {GaxiosOptions, GaxiosPromise, GaxiosResponse} from 'gaxios';
 import {GoogleAuth, GoogleAuthOptions} from 'google-auth-library';
 import * as Pumpify from 'pumpify';
@@ -93,6 +94,13 @@ export interface UploadConfig {
    * system. This maps to the configstore option by the same name.
    */
   configPath?: string;
+
+  /**
+   * For each API request we send, you may specify custom request options that
+   * we'll add onto the request. The request options follow the node-fetch API:
+   * https://github.com/node-fetch/node-fetch#options.
+   */
+  customRequestOptions?: object;
 
   /**
    * This will cause the upload to fail if the current generation of the remote
@@ -190,6 +198,7 @@ export class Upload extends Pumpify {
   authConfig?: {scopes?: string[]};
   authClient: GoogleAuth;
   cacheKey: string;
+  customRequestOptions: object;
   generation?: number;
   key?: string | Buffer;
   kmsKeyName?: string;
@@ -240,6 +249,7 @@ export class Upload extends Pumpify {
     }
     this.cacheKey = cacheKeyElements.join('/');
 
+    this.customRequestOptions = cfg.customRequestOptions || {};
     this.file = cfg.file;
     this.generation = cfg.generation;
     this.kmsKeyName = cfg.kmsKeyName;
@@ -552,7 +562,8 @@ export class Upload extends Pumpify {
       );
     };
 
-    const res = await this.authClient.request(reqOpts);
+    const combinedReqOpts = extend(true, {}, this.customRequestOptions, reqOpts);
+    const res = await this.authClient.request(combinedReqOpts);
     if (res.data && res.data.error) {
       throw res.data.error;
     }
@@ -570,7 +581,8 @@ export class Upload extends Pumpify {
     reqOpts.signal = controller.signal;
     reqOpts.validateStatus = () => true;
 
-    const res = await this.authClient.request(reqOpts);
+    const combinedReqOpts = extend(true, {}, this.customRequestOptions, reqOpts);
+    const res = await this.authClient.request(combinedReqOpts);
     this.onResponse(res);
     return res;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@
 import AbortController from 'abort-controller';
 import * as ConfigStore from 'configstore';
 import {createHash} from 'crypto';
-const extend = require('extend');
+import * as extend from 'extend';
 import {GaxiosOptions, GaxiosPromise, GaxiosResponse} from 'gaxios';
 import {GoogleAuth, GoogleAuthOptions} from 'google-auth-library';
 import * as Pumpify from 'pumpify';
@@ -562,7 +562,12 @@ export class Upload extends Pumpify {
       );
     };
 
-    const combinedReqOpts = extend(true, {}, this.customRequestOptions, reqOpts);
+    const combinedReqOpts = extend(
+      true,
+      {},
+      this.customRequestOptions,
+      reqOpts
+    );
     const res = await this.authClient.request(combinedReqOpts);
     if (res.data && res.data.error) {
       throw res.data.error;
@@ -581,7 +586,12 @@ export class Upload extends Pumpify {
     reqOpts.signal = controller.signal;
     reqOpts.validateStatus = () => true;
 
-    const combinedReqOpts = extend(true, {}, this.customRequestOptions, reqOpts);
+    const combinedReqOpts = extend(
+      true,
+      {},
+      this.customRequestOptions,
+      reqOpts
+    );
     const res = await this.authClient.request(combinedReqOpts);
     this.onResponse(res);
     return res;

--- a/test/test.ts
+++ b/test/test.ts
@@ -936,7 +936,8 @@ describe('gcs-resumable-upload', () => {
       mockAuthorizeRequest();
       up.authClient = {
         request: (reqOpts: GaxiosOptions) => {
-          const customHeader = reqOpts.headers && reqOpts.headers['X-My-Header'];
+          const customHeader =
+            reqOpts.headers && reqOpts.headers['X-My-Header'];
           assert.strictEqual(customHeader, 'My custom value');
           setImmediate(done);
           return {};
@@ -1077,7 +1078,8 @@ describe('gcs-resumable-upload', () => {
       mockAuthorizeRequest();
       up.authClient = {
         request: (reqOpts: GaxiosOptions) => {
-          const customHeader = reqOpts.headers && reqOpts.headers['X-My-Header'];
+          const customHeader =
+            reqOpts.headers && reqOpts.headers['X-My-Header'];
           assert.strictEqual(customHeader, 'My custom value');
           setImmediate(done);
           return {};

--- a/test/test.ts
+++ b/test/test.ts
@@ -76,6 +76,7 @@ describe('gcs-resumable-upload', () => {
   let up: any;
 
   const BUCKET = 'bucket-name';
+  const CUSTOM_REQUEST_OPTIONS = {headers: {'X-My-Header': 'My custom value'}};
   const FILE = 'file-name';
   const GENERATION = Date.now();
   const METADATA = {contentLength: 1024, contentType: 'application/json'};
@@ -101,6 +102,7 @@ describe('gcs-resumable-upload', () => {
     up = upload({
       bucket: BUCKET,
       file: FILE,
+      customRequestOptions: CUSTOM_REQUEST_OPTIONS,
       generation: GENERATION,
       metadata: METADATA,
       origin: ORIGIN,
@@ -134,6 +136,15 @@ describe('gcs-resumable-upload', () => {
 
     it('should localize the cacheKey', () => {
       assert.strictEqual(up.cacheKey, [BUCKET, FILE, GENERATION].join('/'));
+    });
+
+    it('should localize customRequestOptions', () => {
+      assert.strictEqual(up.customRequestOptions, CUSTOM_REQUEST_OPTIONS);
+    });
+
+    it('should default customRequestOptions to empty object', () => {
+      const up = upload({bucket: BUCKET, file: FILE});
+      assert.deepStrictEqual(up.customRequestOptions, {});
     });
 
     it('should include ZERO generation value in the cacheKey', () => {
@@ -912,6 +923,28 @@ describe('gcs-resumable-upload', () => {
       assert.deepStrictEqual(res.headers, {});
     });
 
+    it('should combine customRequestOptions', done => {
+      const up = upload({
+        bucket: BUCKET,
+        file: FILE,
+        customRequestOptions: {
+          headers: {
+            'X-My-Header': 'My custom value',
+          },
+        },
+      });
+      mockAuthorizeRequest();
+      up.authClient = {
+        request: (reqOpts: GaxiosOptions) => {
+          const customHeader = reqOpts.headers && reqOpts.headers['X-My-Header'];
+          assert.strictEqual(customHeader, 'My custom value');
+          setImmediate(done);
+          return {};
+        },
+      };
+      up.makeRequest(REQ_OPTS);
+    });
+
     it('should execute the callback with a body error & response', async () => {
       const error = new GaxiosError('Error message', {}, {
         config: {},
@@ -1026,6 +1059,28 @@ describe('gcs-resumable-upload', () => {
         request: (reqOpts: GaxiosOptions) => {
           assert.strictEqual(reqOpts.validateStatus!(0), true);
           done();
+        },
+      };
+      up.makeRequestStream(REQ_OPTS);
+    });
+
+    it('should combine customRequestOptions', done => {
+      const up = upload({
+        bucket: BUCKET,
+        file: FILE,
+        customRequestOptions: {
+          headers: {
+            'X-My-Header': 'My custom value',
+          },
+        },
+      });
+      mockAuthorizeRequest();
+      up.authClient = {
+        request: (reqOpts: GaxiosOptions) => {
+          const customHeader = reqOpts.headers && reqOpts.headers['X-My-Header'];
+          assert.strictEqual(customHeader, 'My custom value');
+          setImmediate(done);
+          return {};
         },
       };
       up.makeRequestStream(REQ_OPTS);


### PR DESCRIPTION
This allows a user to define custom request options, e.g. custom headers, when instantiating a gcs-resumable-upload instance.